### PR TITLE
Change image source for Trivy to local

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -47,6 +47,7 @@ jobs:
             org.opencontainers.image.vendor=MorganKryze
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -65,7 +66,7 @@ jobs:
       - name: Run Trivy security scan
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/morgankryze/carousel:unstable
+          image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -51,6 +51,7 @@ jobs:
             org.opencontainers.image.vendor=MorganKryze
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -69,7 +70,7 @@ jobs:
       - name: Run Trivy security scan
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/morgankryze/carousel:${{ github.event.release.tag_name }}
+          image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
# Description

Change image source for Trivy to local

## FIXED 🐛

- targeting local image from previous build instead of pulling from registry as it is not pushed

## Related Tickets & Documents 📑

#27 

## Documentation 📜

- [ ] ✅ Docs added
- [ ] 🚧 Writing docs
- [ ] ❌ No docs added
- [x] ⏩ No docs needed

## Tests 🔍

- [ ] ✅ Features totally covered
- [ ] 🚧 Features tests incomplete
- [ ] ❌ No tests added
- [x] ⏩ No tests needed
